### PR TITLE
Handle warnings

### DIFF
--- a/src/Chirp.Razor/Pages/Public.cshtml.cs
+++ b/src/Chirp.Razor/Pages/Public.cshtml.cs
@@ -7,7 +7,7 @@ namespace Chirp.Razor.Pages;
 public class PublicModel : PageModel
 {
 	private readonly ICheepRepository _repository;
-	public List<CheepViewModel> Cheeps { get; set; }
+	public required List<CheepViewModel> Cheeps { get; set; }
 
 	public PublicModel(ICheepRepository repository)
 	{

--- a/src/Chirp.Razor/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Razor/Pages/UserTimeline.cshtml.cs
@@ -7,7 +7,7 @@ namespace Chirp.Razor.Pages;
 public class UserTimelineModel : PageModel
 {
 	private readonly ICheepRepository _repository;
-	public List<CheepViewModel> Cheeps { get; set; }
+	public required List<CheepViewModel> Cheeps { get; set; }
 
 	public UserTimelineModel(ICheepRepository repository)
 	{


### PR DESCRIPTION
Certain properties in the pages have been set to 'required' to handle warnings of the following type:

![image](https://github.com/ITU-BDSA23-GROUP5/Chirp/assets/117824401/e3cc718f-ec5b-4a57-afb0-5de5ec92860b)
