### PR TITLE
config appsettings.development to use chirp-app-dev to run on localhost

### DIFF
--- a/src/Chirp.Web/appsettings.Development.json
+++ b/src/Chirp.Web/appsettings.Development.json
@@ -1,4 +1,14 @@
 {
+  "AzureADB2C": {
+    "Instance": "https://bdsagroup5.b2clogin.com",
+    "Domain": "bdsagroup5.onmicrosoft.com",
+    "TenantId": "28802dfb-864a-4bd8-997b-845397fd5880",
+    "ClientId": "c9c66557-9dc8-4713-a78f-2936aca62180",
+    "ClientCapabilities": ["cp1"],
+    "CallbackPath": "/signin-oidc",
+    "SignUpSignInPolicyId": "B2C_1_susi_dev",
+    "SignedOutCallbackPath": "/signout-callback-oidc"
+  },
   "DetailedErrors": true,
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
A new chirp-app-dev azure ADB2C app has been added to the tenet that also contains chirp-app.
Requires new user-secret for the development machines.

Co-authored-by: Johan <johbr@itu.dk>
