### PR TITLE
max displayed cheep time accuracy is in seconds & removed http launch profile

### DIFF
--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -38,7 +38,7 @@ namespace Chirp.Infrastructure.Repositories
 				{
 					AuthorName = c.Author.Name,
 					Message = c.Text,
-					TimeStamp = c.TimeStamp.ToString()
+					TimeStamp = c.TimeStamp.ToString("yyyy-MM-dd H:mm:ss")
 				})
 				.ToList();
 		}

--- a/src/Chirp.Web/Properties/launchSettings.json
+++ b/src/Chirp.Web/Properties/launchSettings.json
@@ -8,15 +8,6 @@
     }
   },
   "profiles": {
-    "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "http://localhost:5273",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,


### PR DESCRIPTION
Thus, https is now default launch profile
