### PR TITLE
fix timestamps on user timelines

### DIFF
--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -57,7 +57,7 @@ namespace Chirp.Infrastructure.Repositories
 				{
 					AuthorName = c.Author.Name,
 					Message = c.Text,
-					TimeStamp = c.TimeStamp.ToString()
+					TimeStamp = c.TimeStamp.ToString("yyyy-MM-dd H:mm:ss")
 				})
 				.ToList();
 		}


### PR DESCRIPTION
We forgot to add the DateTime formatting string to the GetCheepsFromAuthor-method, thus making the timestamps too long only on the user timelines.