### PR TITLE
Remove insertions with indexes in repositories

### DIFF
--- a/src/Chirp.Core/DTOs/CreateCheepDTO.cs
+++ b/src/Chirp.Core/DTOs/CreateCheepDTO.cs
@@ -1,8 +1,5 @@
-using System.Dynamic;
-
 public class CreateCheepDTO
 {
-	public Guid CheepGuid { get; set; }
 	public required string Text { get; set; }
 	public required string Name { get; set; }
 	public required string Email { get; set; } 

--- a/src/Chirp.Core/Interfaces/IAuthorRepository.cs
+++ b/src/Chirp.Core/Interfaces/IAuthorRepository.cs
@@ -2,5 +2,5 @@ public interface IAuthorRepository
 {
 	public List<AuthorDTO> GetAuthorByName(string name);
 	public List<AuthorDTO> GetAuthorByEmail(string email);
-	public void CreateNewAuthor(Guid id, string name, string email);
+	public void CreateNewAuthor(string name, string email);
 }

--- a/src/Chirp.Infrastructure/Repositories/AuthorRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/AuthorRepository.cs
@@ -9,7 +9,7 @@
 			_context = context;
 		}
 
-		public void CreateNewAuthor(Guid id, string name, string email)
+		public void CreateNewAuthor(string name, string email)
 		{
 			var existing = GetAuthorByEmail(email);
 			if (existing.Any())
@@ -17,11 +17,9 @@
 				Console.WriteLine("Author " + email + " already exists. No new author was made");
 				return;
 			}
-			_context.Authors.Add(new Author { AuthorId = GetHumanReadableId(id), Name = name, Email = email, Cheeps = new List<Cheep>() });
+			_context.Authors.Add(new Author { Name = name, Email = email, Cheeps = new List<Cheep>() });
 			_context.SaveChanges();
 		}
-
-		private int GetHumanReadableId(Guid id) { return id.GetHashCode(); }
 
 		public List<AuthorDTO> GetAuthorByEmail(string email)
 		{

--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -20,7 +20,6 @@ namespace Chirp.Infrastructure.Repositories
 
 			_context.Cheeps.Add(new Cheep
 			{
-				CheepId = GetHumanReadableId(cheep.CheepGuid),
 				AuthorId = author.AuthorId,
 				Author = author,
 				Text = cheep.Text,
@@ -28,8 +27,6 @@ namespace Chirp.Infrastructure.Repositories
 			});
 			_context.SaveChanges();
 		}
-
-		private int GetHumanReadableId(Guid id) { return id.GetHashCode(); }
 
 		public List<CheepDTO> GetCheeps(int page)
 		{

--- a/src/Chirp.Web/Pages/Public/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public/Public.cshtml.cs
@@ -49,12 +49,11 @@ public class PublicModel : PageModel
 
 		if (AuthorRepository.GetAuthorByEmail(email).SingleOrDefault() == null)
 		{
-			AuthorRepository.CreateNewAuthor(new Guid(), name, email);
+			AuthorRepository.CreateNewAuthor(name, email);
 		}
 
 		CreateCheepDTO cheep = new CreateCheepDTO()
 		{
-			CheepGuid = new Guid(),
 			Text = CheepMessage,
 			Name = name,
 			Email = email

--- a/src/Chirp.Web/Pages/Public/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public/UserTimeline.cshtml.cs
@@ -49,12 +49,11 @@ public class UserTimelineModel : PageModel
 
 		if (AuthorRepository.GetAuthorByEmail(email).SingleOrDefault() == null)
 		{
-			AuthorRepository.CreateNewAuthor(new Guid(), name, email);
+			AuthorRepository.CreateNewAuthor(name, email);
 		}
 
 		CreateCheepDTO cheep = new CreateCheepDTO()
 		{
-			CheepGuid = new Guid(),
 			Text = CheepMessage,
 			Name = name,
 			Email = email

--- a/test/Chirp.Infrastructure.Tests/AuthorRepositoryUnitTests.cs
+++ b/test/Chirp.Infrastructure.Tests/AuthorRepositoryUnitTests.cs
@@ -42,12 +42,11 @@ namespace Chirp.Infrastructure.Tests
 		public void CreateNewAuthor_SingleInDatabase()
 		{
             // Arrange
-            Guid id = new Guid();
             string name = "Alice";
             string email = "Alice@itu.dk";
 
             // Act
-            _authorRepository.CreateNewAuthor(id, name, email);
+            _authorRepository.CreateNewAuthor(name, email);
             var authorAlice = _context.Authors.Where(c => c.Name == "Alice");
 
 			// Assert
@@ -59,12 +58,11 @@ namespace Chirp.Infrastructure.Tests
 		public void CreateNewAuthor_WithValues_ExistsInDatabase()
 		{
 			// Arrange
-			Guid id = new Guid();
 			string name = "John Doe";
 			string email = "JohnDoe@itu.dk";
 
 			// Act
-			_authorRepository.CreateNewAuthor(id, name, email);
+			_authorRepository.CreateNewAuthor(name, email);
 
 			var authors = _authorRepository.GetAuthorByName("John Doe");
 			AuthorDTO author = authors.First();

--- a/test/Chirp.Infrastructure.Tests/CheepRepositoryUnitTests.cs
+++ b/test/Chirp.Infrastructure.Tests/CheepRepositoryUnitTests.cs
@@ -49,7 +49,6 @@ public class CheepRepositoryUnitTests : IAsyncLifetime
 
 		CreateCheepDTO cheep = new CreateCheepDTO()
 		{
-			CheepGuid = new Guid(),
 			Text = cheepMessage,
 			Name = name,
 			Email = email
@@ -76,8 +75,7 @@ public class CheepRepositoryUnitTests : IAsyncLifetime
 	public void CreateNewCheep_WithValues_ExistsInDatabase()
 	{
 		// Arrange
-		var author = new Author() { AuthorId = 13, Name = "John Doe", Email = "Johndoe@hotmail.com", Cheeps = new List<Cheep>() };
-		Guid CheepId = new Guid();
+		var author = new Author() { Name = "John Doe", Email = "Johndoe@hotmail.com", Cheeps = new List<Cheep>() };
 		string text = "Hello world!";
 		_context.Authors.Add(author);
 		_context.SaveChanges();
@@ -85,7 +83,6 @@ public class CheepRepositoryUnitTests : IAsyncLifetime
 		// Act
 		_cheepRepository.CreateNewCheep(new CreateCheepDTO
 		{
-			CheepGuid = CheepId,
 			Name = author.Name,
 			Email = author.Email,
 			Text = text


### PR DESCRIPTION
This branch removes the use of GUIDs and the usage of indexes when creating authors and cheeps. In the current state of the program, the ids stored in the database are integers. The idea of passing GUIDs was to abide by CQS, by not having a command return the id, but nowhere do we use the id beyond the point of creation.
Using MSSQL also means that insertion of items in the database with ids require an inelegant workaround.

IAuthorRepository:
To stay backwards compatible, an alternative to removing GUID from the AuthorRepo. interface would be adding a different signature that didn't include it. As we're early in development and usage has been replaced in a few places, I take that this isn't necessary.