### PR TITLE
Ensure user creation on public page

### DIFF
--- a/src/Chirp.Infrastructure/Repositories/AuthorRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/AuthorRepository.cs
@@ -13,15 +13,8 @@ namespace Chirp.Infrastructure.Repositories
 
 		public void CreateNewAuthor(string name, string email)
 		{
-			try
-			{
-				_context.Authors.Add(new Author { Name = name, Email = email, Cheeps = new List<Cheep>() });
-				_context.SaveChanges();
-			}
-			catch (Exception)
-			{
-				throw new Exception("Error when creating new author");
-			}
+			_context.Authors.Add(new Author { Name = name, Email = email, Cheeps = new List<Cheep>() });
+			_context.SaveChanges();
 		}
 
 		public AuthorDTO? GetAuthorByEmail(string email)

--- a/src/Chirp.Web/Pages/Private/User.cshtml.cs
+++ b/src/Chirp.Web/Pages/Private/User.cshtml.cs
@@ -1,7 +1,6 @@
 using Chirp.Core;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http.Extensions;
-using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
@@ -53,6 +52,7 @@ namespace MyApp.Namespace
 		public ActionResult OnPostDelete()
 		{
 			AuthorRepository.DeleteAuthorByName(User.Identity?.Name!);
+			Response.Cookies.Delete("AuthorCreated");
 			return Redirect("/");
 		}
 

--- a/src/Chirp.Web/Pages/Public/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public/Public.cshtml.cs
@@ -91,7 +91,7 @@ public class PublicModel : PageModel
 
 		return Page();
 	}
-	public async Task<IActionResult> OnPost()
+	public IActionResult OnPost()
 	{
 		InvalidCheep = false;
 		try
@@ -102,20 +102,10 @@ public class PublicModel : PageModel
 			}
 
 			string name = (User.Identity?.Name) ?? throw new Exception("Error in getting username");
-			AuthorDTO? user = AuthorRepository.GetAuthorByName(name);
+			AuthorDTO? user = AuthorRepository.GetAuthorByName(name)
+				?? throw new Exception("User not found!");
 
-			if (user == null)
-			{
-				string token = User.FindFirst("idp_access_token")?.Value
-					?? throw new Exception("Github token not found");
-
-				string email = await GithubHelper.GetUserEmailGithub(token, name);
-
-				AuthorRepository.CreateNewAuthor(name, email);
-				user = AuthorRepository.GetAuthorByName(name) ?? throw new Exception("Error when getting user with name: " + name);
-			}
-
-			CreateCheepDTO cheep = new CreateCheepDTO()
+            CreateCheepDTO cheep = new CreateCheepDTO()
 			{
 				Text = CheepMessage,
 				Name = user.Name,
@@ -172,19 +162,8 @@ public class PublicModel : PageModel
 		return Redirect(ReturnUrl ?? "/");
 	}
 
-	public async Task<IActionResult> OnPostFollow(string followeeName, string followerName)
+	public IActionResult OnPostFollow(string followeeName, string followerName)
 	{
-		string name = (User.Identity?.Name) ?? throw new Exception("Name is null!");
-
-		if (AuthorRepository.GetAuthorByName(name) == null)
-		{
-			string token = User.FindFirst("idp_access_token")?.Value
-					?? throw new Exception("Github token not found");
-			string email = await GithubHelper.GetUserEmailGithub(token, name);
-
-			AuthorRepository.CreateNewAuthor(name, email);
-		}
-
 		AuthorRepository.FollowAuthor(followerName ?? throw new Exception("Name is null!"), followeeName);
 		return Redirect(ReturnUrl ?? "/");
 	}

--- a/src/Chirp.Web/Pages/Public/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public/Public.cshtml.cs
@@ -1,4 +1,4 @@
-﻿using Chirp.Core;
+﻿﻿using Chirp.Core;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -69,6 +69,7 @@ public class PublicModel : PageModel
 			catch (Exception e)
 			{
 				Console.WriteLine($"User creation failed: {e}");
+				return;
 			}
 		}
 		

--- a/src/Chirp.Web/Pages/Public/Trending.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public/Trending.cshtml.cs
@@ -46,7 +46,7 @@ public class TrendingModel : PageModel
 
 		return Page();
 	}
-	public async Task<IActionResult> OnPost()
+	public IActionResult OnPost()
 	{
 		InvalidCheep = false;
 		try
@@ -57,20 +57,10 @@ public class TrendingModel : PageModel
 			}
 
 			string name = (User.Identity?.Name) ?? throw new Exception("Error in getting username");
-			AuthorDTO? user = AuthorRepository.GetAuthorByName(name);
+			AuthorDTO? user = AuthorRepository.GetAuthorByName(name)
+				?? throw new Exception("User not found!");
 
-			if (user == null)
-			{
-				string token = User.FindFirst("idp_access_token")?.Value
-					?? throw new Exception("Github token not found");
-
-				string email = await GithubHelper.GetUserEmailGithub(token, name);
-
-				AuthorRepository.CreateNewAuthor(name, email);
-				user = AuthorRepository.GetAuthorByName(name) ?? throw new Exception("Error when getting user with name: " + name);
-			}
-
-			CreateCheepDTO cheep = new CreateCheepDTO()
+            CreateCheepDTO cheep = new CreateCheepDTO()
 			{
 				Text = CheepMessage,
 				Name = user.Name,
@@ -129,19 +119,8 @@ public class TrendingModel : PageModel
 		return Redirect(ReturnUrl ?? "/");
 	}
 
-	public async Task<IActionResult> OnPostFollow(string followeeName, string followerName)
+	public IActionResult OnPostFollow(string followeeName, string followerName)
 	{
-		string name = (User.Identity?.Name) ?? throw new Exception("Name is null!");
-
-		if (AuthorRepository.GetAuthorByName(name) == null)
-		{
-			string token = User.FindFirst("idp_access_token")?.Value
-					?? throw new Exception("Github token not found");
-			string email = await GithubHelper.GetUserEmailGithub(token, name);
-
-			AuthorRepository.CreateNewAuthor(name, email);
-		}
-
 		AuthorRepository.FollowAuthor(followerName ?? throw new Exception("Name is null!"), followeeName);
 		return Redirect(ReturnUrl ?? "/");
 	}

--- a/src/Chirp.Web/Pages/Public/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public/UserTimeline.cshtml.cs
@@ -1,7 +1,6 @@
 using Chirp.Core;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.Http.Extensions;
 using FluentValidation;
 
 namespace Chirp.Web.Pages;
@@ -54,7 +53,7 @@ public class UserTimelineModel : PageModel
 		return Page();
 	}
 
-	public async Task<IActionResult> OnPost()
+	public IActionResult OnPost()
 	{
 		InvalidCheep = false;
 		try
@@ -65,19 +64,8 @@ public class UserTimelineModel : PageModel
 			}
 
 			string name = (User.Identity?.Name) ?? throw new Exception("Error in getting username");
-			AuthorDTO? user = AuthorRepository.GetAuthorByName(name);
-
-			if (user == null)
-			{
-				string token = User.FindFirst("idp_access_token")?.Value
-					?? throw new Exception("Github token not found");
-
-
-				string email = await GithubHelper.GetUserEmailGithub(token, name);
-
-				AuthorRepository.CreateNewAuthor(name, email);
-				user = AuthorRepository.GetAuthorByName(name) ?? throw new Exception("Error when getting user with name: " + name);
-			}
+			AuthorDTO? user = AuthorRepository.GetAuthorByName(name)
+				?? throw new Exception("User not found!");
 
 			CreateCheepDTO cheep = new CreateCheepDTO()
 			{
@@ -136,18 +124,8 @@ public class UserTimelineModel : PageModel
 		return Redirect(ReturnUrl ?? "/");
 	}
 
-	public async Task<IActionResult> OnPostFollow(string followeeName, string followerName)
+	public IActionResult OnPostFollow(string followeeName, string followerName)
 	{
-		string name = (User.Identity?.Name) ?? throw new Exception("Name is null!");
-
-		if (AuthorRepository.GetAuthorByName(name) == null)
-		{
-			string token = User.FindFirst("idp_access_token")?.Value
-					?? throw new Exception("Github token not found");
-			string email = await GithubHelper.GetUserEmailGithub(token, name);
-			AuthorRepository.CreateNewAuthor(name, email);
-		}
-
 		AuthorRepository.FollowAuthor(followerName ?? throw new Exception("Name is null!"), followeeName);
 		return Redirect(ReturnUrl ?? "/");
 	}


### PR DESCRIPTION
Ensuring user creation is only done on the public page, as logging in will redirect the user there.

Upon not being able to create the user, the error is written to the console as this shouldn't affect the user.